### PR TITLE
Fix error relating to missing app module

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -6,9 +6,11 @@ services:
       - "35789:35729"
     environment:
       CT_URL: http://mymachine:9000
+      NODE_PATH: app/src
       LOCAL_URL: http://mymachine:3095
       CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
       API_VERSION: v1
+      FASTLY_ENABLED: "false"
       GCLOUD_CREDENTIALS: ${GCLOUD_CREDENTIALS}
     command: develop
     volumes:


### PR DESCRIPTION
This PR fixes the following error `Cannot find module 'app'` when trying to use docker for local development. This error occurs due to the `NODE_PATH` environment variable not being set.